### PR TITLE
Remove use of env

### DIFF
--- a/.github/workflows/azure-static-web-apps-gentle-meadow-0d236b010.yml
+++ b/.github/workflows/azure-static-web-apps-gentle-meadow-0d236b010.yml
@@ -8,13 +8,9 @@ on:
     types: [opened, synchronize, reopened, closed]
     branches:
       - main
-      
-env:
-  AZURE_API_KEY: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_GENTLE_MEADOW_0D236B010 }}
-
 jobs:
   build_and_deploy_job:
-    if: ${{ env.AZURE_API_KEY }} != '' && (github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed'))
+    if: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_GENTLE_MEADOW_0D236B010 }} != '' && (github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed'))
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:
@@ -34,7 +30,7 @@ jobs:
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v1
         with:
-          azure_static_web_apps_api_token: ${{ env.AZURE_API_KEY }}
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_GENTLE_MEADOW_0D236B010 }}
           repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for Github integrations (i.e. PR comments)
           action: "upload"
           ###### Repository/Build Configurations - These values can be configured to match your app requirements. ######
@@ -47,7 +43,7 @@ jobs:
           ###### End of Repository/Build Configurations ######
 
   close_pull_request_job:
-    if: ${{ env.AZURE_API_KEY }} != '' && (github.event_name == 'pull_request' && github.event.action == 'closed')
+    if: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_GENTLE_MEADOW_0D236B010 }} != '' && (github.event_name == 'pull_request' && github.event.action == 'closed')
     runs-on: ubuntu-latest
     name: Close Pull Request Job
     steps:
@@ -55,5 +51,5 @@ jobs:
         id: closepullrequest
         uses: Azure/static-web-apps-deploy@v1
         with:
-          azure_static_web_apps_api_token: ${{ env.AZURE_API_KEY }}
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_GENTLE_MEADOW_0D236B010 }}
           action: "close"


### PR DESCRIPTION
Using env is [currently broken](https://github.community/t/how-to-use-env-context/16975/6)

Revert to using secret.XXXXX